### PR TITLE
Add LDAP authentication backend with sample env

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "async": "~1.3.0",
     "phantom": "~0.7.2",
     "dav": "~1.7.6",
-    "request": "~2.60.0"
+    "request": "~2.60.0",
+    "ldapjs": "mcavage/node-ldapjs",
+    "passport-ldapauth": "0.3.0"
   },
   "devDependencies": {
     "grunt": "~0.4.4",

--- a/server/api/user/user.model.js
+++ b/server/api/user/user.model.js
@@ -4,12 +4,7 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var crypto = require('crypto');
 
-var authTypes = ['webdav'];
-
-var WebDAVSchema = new Schema({
-    username: String,
-    password: String
-});
+var authTypes = ['webdav', 'ldap'];
 
 var UserSchema = new Schema({
   name: String,

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -6,10 +6,10 @@ var config = require('../config/environment');
 var User = require('../api/user/user.model');
 
 // Passport Configuration
-require('./' + config.auth + '/passport').setup(User, config);
+require('./' + config.auth.type + '/passport').setup(User, config);
 
 var router = express.Router();
 
-router.use('/local', require('./' + config.auth));
+router.use('/local', require('./' + config.auth.type));
 
 module.exports = router;

--- a/server/auth/ldap/index.js
+++ b/server/auth/ldap/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var express = require('express');
+var passport = require('passport');
+var auth = require('../auth.service');
+
+var router = express.Router();
+
+router.post('/', function(req, res, next) {
+  passport.authenticate('ldapauth', function (err, user, info) {
+    var error = err || info;
+    if (error) return res.json(401, error);
+    if (!user) return res.json(404, {message: 'Something went wrong, please try again.'});
+
+    var token = auth.signToken(user._id, user.role);
+    res.json({token: token});
+  })(req, res, next)
+});
+
+module.exports = router;

--- a/server/auth/ldap/passport.js
+++ b/server/auth/ldap/passport.js
@@ -1,0 +1,55 @@
+var passport = require('passport');
+var LdapStrategy = require('passport-ldapauth');
+
+exports.setup = function (User, config) {
+  passport.use(new LdapStrategy({
+      server: {
+          url: config.auth.ldap.server,
+          searchBase: config.auth.ldap.base,
+          searchFilter: config.auth.ldap.filter,
+          bindDn: config.auth.ldap.bindDn,
+          bindCredentials: config.auth.ldap.bindPw,
+          searchAttributes: ['cn']
+      },
+      usernameField: 'email',
+      passwordField: 'password',
+      passReqToCallback: true,
+      badRequestMessage: true,
+      invalidCredentials: true,
+      userNotFound: true,
+      constraintViolation: true
+    },
+    function(req, ldapUser, done) {
+        var email = req.body.email,
+            password = req.body.password,
+            fullName = ldapUser.cn;
+
+        User.findOne({
+            email: email
+        }, function (err, user) {
+            if (err) { return done(err); }
+
+            if (!user) {
+                var newUser = new User({
+                    name: fullName,
+                    email: email,
+                    provider: 'ldap',
+                    role: 'user',
+                    webdav: (config.storage.type === 'webdav') ? {
+                        username: email,
+                        password: password
+                    } : undefined
+                });
+                newUser.save(function (err, user) {
+                    if (err) { return done(err); }
+                    if (!err) {
+                        return done(null, user);
+                    }
+                });
+            } else {
+                return done(null, user);
+            }
+        });
+    }
+  ));
+};

--- a/server/auth/webdav/passport.js
+++ b/server/auth/webdav/passport.js
@@ -14,16 +14,16 @@ exports.setup = function (User, config) {
                 password: password
             })),
             {
-                baseUrl: config.storage.server
+                baseUrl: config.storage.webdav.server
             }
         );
         client.send(
             dav.request.basic({ method: 'OPTIONS', data: ''}),
-            config.storage.path
+            config.storage.webdav.path
         ).then(
             function success() {
                 User.findOne({
-                    email: email.toLowerCase()
+                    email: email
                 }, function (err, user) {
                     if (err) { return done(err); }
 
@@ -33,10 +33,10 @@ exports.setup = function (User, config) {
                             email: email,
                             provider: 'webdav',
                             role: 'user',
-                            webdav: {
+                            webdav: (config.storage.type === 'webdav') ? {
                                 username: email,
                                 password: password
-                            }
+                            } : undefined
                         });
                         newUser.save(function (err, user) {
                             if (err) { return done(err); }

--- a/server/config/environment/index.js
+++ b/server/config/environment/index.js
@@ -41,11 +41,26 @@ var all = {
     }
   },
 
-  auth: process.env.STORAGE || 'local',
+  auth: {
+      type: process.env.AUTH || 'local',
+      'webdav': {
+          server: process.env.WEBDAV_SERVER,
+          path: process.env.WEBDAV_PATH
+      },
+      'ldap': {
+          server: process.env.LDAP_SERVER,
+          base: process.env.LDAP_BASE,
+          filter: process.env.LDAP_FILTER,
+          bindDn: process.env.LDAP_BIND_DN,
+          bindPw: process.env.LDAP_BIND_PW
+      }
+  },
   storage: {
       type: process.env.STORAGE || 'local',
-      server: process.env.WEBDAV_SERVER,
-      path: process.env.WEBDAV_PATH
+      'webdav': {
+          server: process.env.WEBDAV_SERVER,
+          path: process.env.WEBDAV_PATH
+      }
   }
 };
 

--- a/server/config/local.env.sample.js
+++ b/server/config/local.env.sample.js
@@ -14,12 +14,29 @@ module.exports = {
 
   /*
    * Supported authentication strategies.
-   * 1. 'local' for storing everything in Mongo/GridFS, auth using username/password
-   * 2. 'webdav' for linking with a WebDAV server, auth using WebDAV credentials
+   * 1. 'local' for using Manticore's built-in accounts system. Allow signups.
+   * 2. 'webdav' for authenticating against a  WebDAV server. Only login, no signups.
+   * 3. 'ldap' for authenticating against an LDAP service. Only login, no signups.
    */
-  STORAGE: 'webdav',
+  AUTH: 'local',
 
-  // More configuration for the chosen auth type. None required for 'local'
-  WEBDAV_SERVER: 'https://apps.kolabnow.com',
-  WEBDAV_PATH: '/files/Files'
+  /*
+   * Supported storage backends.
+   * 1. 'local' for storing everything in Mongo/GridFS. The fastest and most reliable way.
+   *    Can be used with any AUTH strategy.
+   * 2. 'webdav' for two-way synchronizing of documents with a WebDAV server.
+   *    Can be used if AUTH is 'ldap' or 'webdav'; those credentials are used to talk to the webdav server.
+   */
+  STORAGE: 'local',
+
+  // WebDAV server config, required iff AUTH or STORAGE is 'webdav'.
+  WEBDAV_SERVER: 'https://kolabmachine',
+  WEBDAV_PATH: '/iRony/files/Files',
+
+  // LDAP server config, required iff AUTH is 'ldap'. {{username}} will be replaced with users' logins
+  LDAP_SERVER: 'ldaps://kolabmachine',
+  LDAP_BASE: 'ou=People,dc=test,dc=example,dc=org',
+  LDAP_FILTER: '(&(objectclass=person)(|(uid={{username}})(mail={{username}})))',
+  LDAP_BIND_DN: 'uid=kolab-service,ou=Special Users,dc=test,dc=example,dc=org',
+  LDAP_BIND_PW: 'kolab-service-pass'
 };


### PR DESCRIPTION
Manticore can now outsource it's user authentication backend to an LDAP server.

This can be used in combination with a WebDAV storage backend (the LDAP credentials are reused to auth against the WebDAV server) to let Manticore work with groupware systems like Kolab and others.

Sample configuration options that can work with a Kolab server are provided in `local.env.sample.js` for reference.
