### PR TITLE
Encrypt users' WebDAV credentials

### DIFF
--- a/server/auth/webdav/passport.js
+++ b/server/auth/webdav/passport.js
@@ -1,8 +1,14 @@
 var passport = require('passport');
 var LocalStrategy = require('passport-local').Strategy;
 var dav = require('dav');
+var crypto = require('crypto');
 
 exports.setup = function (User, config) {
+  function encrypt(password) {
+      var cipher = crypto.createCipher('aes-256-cbc', config.storage.webdav.key);
+      return cipher.update(password, 'utf8', 'base64') + cipher.final('base64')
+  }
+
   passport.use(new LocalStrategy({
       usernameField: 'email',
       passwordField: 'password' // this is the virtual field on the model
@@ -35,7 +41,7 @@ exports.setup = function (User, config) {
                             role: 'user',
                             webdav: (config.storage.type === 'webdav') ? {
                                 username: email,
-                                password: password
+                                password: encrypt(password)
                             } : undefined
                         });
                         newUser.save(function (err, user) {

--- a/server/config/environment/index.js
+++ b/server/config/environment/index.js
@@ -45,7 +45,8 @@ var all = {
       type: process.env.AUTH || 'local',
       'webdav': {
           server: process.env.WEBDAV_SERVER,
-          path: process.env.WEBDAV_PATH
+          path: process.env.WEBDAV_PATH,
+          key: process.env.WEBDAV_ENCRYPTION_KEY
       },
       'ldap': {
           server: process.env.LDAP_SERVER,
@@ -59,7 +60,8 @@ var all = {
       type: process.env.STORAGE || 'local',
       'webdav': {
           server: process.env.WEBDAV_SERVER,
-          path: process.env.WEBDAV_PATH
+          path: process.env.WEBDAV_PATH,
+          key: process.env.WEBDAV_ENCRYPTION_KEY
       }
   }
 };

--- a/server/config/local.env.sample.js
+++ b/server/config/local.env.sample.js
@@ -29,9 +29,13 @@ module.exports = {
    */
   STORAGE: 'local',
 
-  // WebDAV server config, required iff AUTH or STORAGE is 'webdav'.
+  /*
+   * WebDAV server config, only if AUTH or STORAGE is 'webdav'.
+   * Make sure you provide an encryption key to protect users' webdav credentials.
+   */
   WEBDAV_SERVER: 'https://kolabmachine',
   WEBDAV_PATH: '/iRony/files/Files',
+  WEBDAV_ENCRYPTION_KEY: 'your-AES-encryption-key',
 
   // LDAP server config, required iff AUTH is 'ldap'. {{username}} will be replaced with users' logins
   LDAP_SERVER: 'ldaps://kolabmachine',


### PR DESCRIPTION
The WebDAV spec doesn't support cookies or authentication tokens that can be used after a successful login.

Therefore we need to encrypt users' WebDAV passwords if the administrator chooses a WebDAV storage backend (Manticore doesn't even store passwords if _only_ WebDAV auth is used).
